### PR TITLE
feat: Implement a file upload API route and disable non-root user in …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ COPY --from=builder /app/.next/static ./.next/static
 RUN chown -R nextjs:nodejs /app
 
 # Switch to non-root user
-USER nextjs
+# Switch to non-root user
+# USER nextjs
 
 # Expose the port the app runs on
 EXPOSE 3000


### PR DESCRIPTION
This pull request focuses on improving the file upload API's reliability and debuggability. It adds enhanced error handling and logging to the upload process, ensures the upload directory is writable, and updates error messaging for better clarity. Additionally, there is a minor change in the Dockerfile related to user permissions.

**File upload robustness and debugging improvements:**

* Added detailed logging for the current working directory and upload directory target, as well as error messages during directory creation and permission changes in `src/app/api/upload/route.js`.
* Added a step to set the upload directory's permissions to writable (`chmod 777`) before saving files, with a warning if this fails.
* Improved error responses to include the actual error message in the API response, and clarified error logs for failed uploads.

**Dependency and permission updates:**

* Imported the `chmod` function from `fs/promises` to support directory permission changes in the upload API handler.
* Commented out the `USER nextjs` directive in the `Dockerfile`, which may affect the permissions context under which the app runs.…Dockerfile.