### PR TITLE
feat: Add GitHub Actions workflow for server deployment via SSH.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to Server
+
+on:
+  # push:
+  #   branches:
+  #     - master
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          script: |
+            ls -la 
+            cd docker/Aiyu/
+            git pull origin master
+            
+            ls -la 
+            docker compose build --memory=512m
+            docker compose up -d 
+            
+ 


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for deploying the project to a server. The workflow enables manual deployment via the GitHub Actions UI and uses SSH credentials stored in secrets to securely connect and deploy the application.

Deployment automation:

* Added a `.github/workflows/deploy.yml` workflow that allows manual deployment (`workflow_dispatch`), connects to the server via SSH using the `appleboy/ssh-action`, and runs commands to pull the latest code and rebuild/restart the Docker containers.