### PR TITLE
feat: move database connection to the try block for sitemap generatio…

### DIFF
--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -4,8 +4,6 @@ import ProjectModel from '@/models/Project';
 import GalleryModel from '@/models/Gallery';
 
 export default async function sitemap() {
-  await dbConnect();
-
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
 
   // Static routes
@@ -55,6 +53,9 @@ export default async function sitemap() {
   ];
 
   try {
+    // Attempt database connection
+    await dbConnect();
+
     // Dynamic blog routes
     const blogs = await BlogModel.find({ published: { $ne: false } }, { slug: 1, updatedAt: 1 }).lean();
     const blogRoutes = blogs.map((blog) => ({
@@ -85,6 +86,7 @@ export default async function sitemap() {
     return [...staticRoutes, ...blogRoutes, ...projectRoutes, ...galleryRoutes];
   } catch (error) {
     console.error('Error generating sitemap:', error);
+    console.warn('Database unavailable during sitemap generation. Returning static routes only.');
     return staticRoutes;
   }
 }


### PR DESCRIPTION
This pull request updates the `sitemap.js` logic to improve error handling and ensure the database connection is attempted within the function's `try` block. This change makes sitemap generation more robust by gracefully handling database connection failures and ensuring that static routes are always returned, even if the database is unavailable.

**Error handling and database connection improvements:**

* Moved the call to `dbConnect()` inside the `try` block to ensure that any connection errors are properly caught and handled. [[1]](diffhunk://#diff-0c6081ab3bc9717b4787a2507e0b9ca6ce032c065a6182505e9b3cc7d0cacc49L7-L8) [[2]](diffhunk://#diff-0c6081ab3bc9717b4787a2507e0b9ca6ce032c065a6182505e9b3cc7d0cacc49R56-R58)
* Added a warning log to indicate when the database is unavailable during sitemap generation, and clarified that only static routes will be returned in such cases.…n and add warning for unavailable database