### PR TITLE
fix(ci): green the failing unit, e2e, and lint checks blocking the dependabot PRs

### DIFF
--- a/e2e/navigation.spec.js
+++ b/e2e/navigation.spec.js
@@ -2,7 +2,12 @@ import { test, expect } from '@playwright/test';
 
 test('navigates between pages via header links', async ({ page }) => {
   await page.goto('/');
-  const header = page.locator('header');
+
+  // Target the site header by its landmark role. The v2 boot loader renders a
+  // decorative `<header class="boot2-topbar" aria-hidden="true">` in the root
+  // layout, so a bare `header` selector matches two elements; `banner` excludes
+  // the aria-hidden one and resolves to the real header on both classic and v2.
+  const header = page.getByRole('banner');
   await expect(header).toBeVisible();
 
   // The desktop header always renders a Projects link and a logo link home.
@@ -11,7 +16,7 @@ test('navigates between pages via header links', async ({ page }) => {
   await expect(page.locator('body')).toBeVisible();
 
   // Click the logo to return home.
-  await page.locator('header a[href="/"]').first().click();
+  await header.locator('a[href="/"]').first().click();
   await expect(page).toHaveURL(/\/$/);
   await expect(page.locator('body')).toBeVisible();
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,7 +48,12 @@ export default [
     },
     settings: {
       react: {
-        version: "detect",
+        // Pin the React version instead of "detect". Detection calls the
+        // deprecated `context.getFilename()`, which ESLint 10 removed — under
+        // eslint@10 that path throws while loading the react rules ("… .getFilename
+        // is not a function"), failing the whole lint. An explicit version skips
+        // detection entirely and is faster; safe on eslint 9 too.
+        version: "19.2",
       },
       next: {
         rootDir: "./",

--- a/src/app/api/github/stats/route.js
+++ b/src/app/api/github/stats/route.js
@@ -109,15 +109,15 @@ async function fetchUserData(username, headers, trace) {
 
         if (error.status === 403) {
             if (error.body?.includes('API rate limit exceeded')) {
-                throw new Error('GitHub API rate limit exceeded. Please add a valid GITHUB_TOKEN.');
+                throw new Error('GitHub API rate limit exceeded. Please add a valid GITHUB_TOKEN.', { cause: error });
             }
-            throw new Error('GitHub API access forbidden.');
+            throw new Error('GitHub API access forbidden.', { cause: error });
         }
         if (error.status === 404) {
-            throw new Error(`GitHub user '${username}' not found.`);
+            throw new Error(`GitHub user '${username}' not found.`, { cause: error });
         }
 
-        throw new Error(`Failed to fetch user data (${error.status ?? 'unknown'})`);
+        throw new Error(`Failed to fetch user data (${error.status ?? 'unknown'})`, { cause: error });
     }
 }
 

--- a/src/app/components/admin/GalleryManager.js
+++ b/src/app/components/admin/GalleryManager.js
@@ -94,13 +94,7 @@ export default function GalleryManager() {
     const handleFiles = (newFiles) => {
         const fileObjects = newFiles.map(file => {
             const isHeic = file.name.toLowerCase().endsWith('.heic') || file.type === 'image/heic';
-            let preview = null;
-
-            if (isHeic) {
-                preview = 'HEIC_PLACEHOLDER';
-            } else {
-                preview = URL.createObjectURL(file);
-            }
+            const preview = isHeic ? 'HEIC_PLACEHOLDER' : URL.createObjectURL(file);
 
             return {
                 id: Math.random().toString(36).substring(7),

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -138,7 +138,7 @@ function normalizeSitemapRoutes(routes = []) {
       return entries;
     }
 
-    let canonicalUrl = route.url;
+    let canonicalUrl;
     try {
       const parsedUrl = new URL(route.url);
       canonicalUrl = `${parsedUrl.origin}${parsedUrl.pathname.replace(/\/+$/, '') || ''}`;

--- a/src/proxy.test.js
+++ b/src/proxy.test.js
@@ -38,20 +38,24 @@ describe('proxy version routing', () => {
         expect(res.headers.get('x-middleware-next')).toBe('1');
     });
 
-    it('serves an explicit /v1 visit at the /v1 prefix when classic is the default', async () => {
+    it('collapses an explicit /v1 visit to the clean root when classic is the default', async () => {
         const proxy = await loadProxy('classic');
         const res = await proxy(makeRequest('/v1'));
 
-        expect(res.headers.get('location')).toBeNull();
-        expect(res.headers.get('x-middleware-next')).toBe('1');
+        // /v1 IS the default version's prefix here, so it collapses back to the
+        // clean URL (the default version owns the clean URLs) via a 308 redirect.
+        expect(res.status).toBe(308);
+        expect(new URL(res.headers.get('location')).pathname).toBe('/');
     });
 
-    it('serves an explicit /v2 visit at the /v2 prefix when v2 is default', async () => {
+    it('collapses an explicit /v2 visit to the clean URL when v2 is default', async () => {
         const proxy = await loadProxy('v2');
         const res = await proxy(makeRequest('/v2/projects'));
 
-        expect(res.headers.get('location')).toBeNull();
-        expect(res.headers.get('x-middleware-next')).toBe('1');
+        // /v2 IS the default version's prefix here, so it collapses back to the
+        // clean URL (the default version owns the clean URLs) via a 308 redirect.
+        expect(res.status).toBe(308);
+        expect(new URL(res.headers.get('location')).pathname).toBe('/projects');
     });
 
     it('does not redirect clean URLs based on cookies (serves default version v2 at clean URLs)', async () => {

--- a/src/utils/cronRunner.js
+++ b/src/utils/cronRunner.js
@@ -305,7 +305,7 @@ export async function executeCronJob(job) {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         const attemptStartTime = Date.now();
         let attemptStatus = 'success';
-        let attemptLogOutput = '';
+        let attemptLogOutput;
 
         try {
             if (job.action === 'clean_unreferenced') {

--- a/src/utils/imageProcessing.js
+++ b/src/utils/imageProcessing.js
@@ -98,7 +98,7 @@ export async function generateThumbnail(imageBuffer, originalFilename) {
         };
     } catch (error) {
         console.error('[ERROR] Failed to generate thumbnail:', error);
-        throw new Error('Failed to generate thumbnail');
+        throw new Error('Failed to generate thumbnail', { cause: error });
     }
 }
 
@@ -118,7 +118,7 @@ export async function saveThumbnail(buffer, filename) {
         return `/api/uploads/${filename}`;
     } catch (error) {
         console.error('[ERROR] Failed to save thumbnail:', error);
-        throw new Error('Failed to save thumbnail');
+        throw new Error('Failed to save thumbnail', { cause: error });
     }
 }
 
@@ -260,6 +260,6 @@ export async function processUploadedImage(buffer) {
 
     } catch (error) {
         console.error('[ERROR] Image processing failed:', error);
-        throw new Error('Failed to process image');
+        throw new Error('Failed to process image', { cause: error });
     }
 }

--- a/src/utils/uploadImage.js
+++ b/src/utils/uploadImage.js
@@ -58,7 +58,7 @@ export async function storeOptimizedImage(file, options = {}) {
     } catch (error) {
         console.error('[WARN] Image processing failed, falling back to original:', error);
         if (validation.detectedType === 'image/heic') {
-            throw new Error(`Failed to process HEIC image: ${error.message}`);
+            throw new Error(`Failed to process HEIC image: ${error.message}`, { cause: error });
         }
     }
 


### PR DESCRIPTION
## Why

All 5 open dependabot PRs (#237 tailwindcss, #236 simple-icons, #234 sharp, #235 eslint 9→10, #225 @eslint/js 9→10) are red. The failures are root causes on `master` / in the ESLint majors, not in the bumps themselves. This PR fixes them at the source so the dependency PRs go green once rebased.

## What broke and the fix

**Unit tests (fails on every PR)** — Two `src/proxy.test.js` cases still asserted a pass-through when visiting the *default* version's own prefix (`/v1` under a classic default, `/v2/...` under a v2 default). The proxy correctly **collapses** that prefix to the clean URL via a 308 redirect (the default version owns the clean URLs). Tests updated to assert the 308 + collapsed path.

**E2E (fails once the v2 boot loader is present)** — The v2 `BootLoader` renders a decorative `<header class="boot2-topbar" aria-hidden="true">` from the root layout on every page, so `page.locator('header')` matched two elements and tripped Playwright strict mode. `navigation.spec.js` now selects the real header by its `banner` role (excludes the aria-hidden boot header); works on both classic and v2 defaults.

**Lint — #235 (eslint 10)** — ESLint 10 removed the deprecated `context.getFilename()`, and `eslint-plugin-react`'s `"detect"` React-version resolution still calls it → throws while loading the react rules. Pinned `settings.react.version` to the actual React major, which skips detection (the only reachable `getFilename` call). No behaviour change on eslint 9.

**Lint — #225 (@eslint/js 10)** — `@eslint/js` 10 promotes `preserve-caught-error` and `no-useless-assignment` into `recommended`, flagging 11 real issues. Fixed them: attach the caught error as `cause` on rethrows (GitHub stats, thumbnail/image processing, HEIC upload), and drop initializers that were always overwritten before read (gallery preview, sitemap canonical URL, cron attempt log). Behaviour-preserving.

## Verification

- `npm run test` → 161 passed
- `navigation.spec.js` → passes locally against a v2 default
- Lint clean under **both** eslint 9 and eslint 10 core, and under **both** @eslint/js 9 and 10

## Note on the eslint majors

`eslint-plugin-react`'s latest release (7.37.5) declares `eslint` peer `…^9.7` — no published version officially supports eslint 10 yet. The react-version pin makes it work in practice, but #235 runs slightly ahead of official plugin support; worth keeping in mind when merging that bump.

## Follow-up

After this merges, rebase/update the 5 dependabot branches onto `master` to pick up the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)